### PR TITLE
perf: only redraw if there are axisLabels present

### DIFF
--- a/jquery.flot.axislabels.js
+++ b/jquery.flot.axislabels.js
@@ -327,6 +327,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
         var defaultPadding = 2;  // padding between axis and tick labels
         plot.hooks.draw.push(function (plot, ctx) {
+            var hasAxisLabels = false;
             if (!secondPass) {
                 // MEASURE AND SET OPTIONS
                 $.each(plot.getAxes(), function(axisName, axis) {
@@ -335,6 +336,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     if (!opts || !opts.axisLabel || !axis.show)
                         return;
 
+                    hasAxisLabels = true;
                     var renderer = null;
 
                     if (!opts.axisLabelUseHtml &&
@@ -384,10 +386,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                     opts.labelHeight = axis.labelHeight;
                     opts.labelWidth = axis.labelWidth;
                 });
-                // re-draw with new label widths and heights
-                secondPass = true;
-                plot.setupGrid();
-                plot.draw();
+                // if there are axis labels re-draw with new label widths and heights
+                if (hasAxisLabels) {
+                    secondPass = true;
+                    plot.setupGrid();
+                    plot.draw();
+                }
             } else {
                 // DRAW
                 $.each(plot.getAxes(), function(axisName, axis) {


### PR DESCRIPTION
- avoid doing the double drawing when there are no axis labels
- obviousily twice as fast for graphs with out axis labels
