### PR TITLE
Fixed problem with IE9 and the labels position

### DIFF
--- a/jquery.flot.axislabels.js
+++ b/jquery.flot.axislabels.js
@@ -188,13 +188,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             '-o-transform': '',
             '-ms-transform': ''
         };
-        if (x != 0 || y != 0) {
-            var stdTranslate = ' translate(' + x + 'px, ' + y + 'px)';
-            stransforms['-moz-transform'] += stdTranslate;
-            stransforms['-webkit-transform'] += stdTranslate;
-            stransforms['-o-transform'] += stdTranslate;
-            stransforms['-ms-transform'] += stdTranslate;
-        }
+
         if (degrees != 0) {
             var rotation = degrees / 90;
             var stdRotate = ' rotate(' + degrees + 'deg)';
@@ -203,7 +197,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             stransforms['-o-transform'] += stdRotate;
             stransforms['-ms-transform'] += stdRotate;
         }
-        var s = 'top: 0; left: 0; ';
+    	
+        var s = 'top: ' + y + 'px; left: ' + x + 'px; ';
+		
         for (var prop in stransforms) {
             if (stransforms[prop]) {
                 s += prop + ':' + stransforms[prop] + ';';


### PR DESCRIPTION
Changed the CSS property used to set the label position from -[browser]-transform to top and left properties.
