### PR TITLE
Use axisLabelColour (if set) for html labels, or omit inline css color

### DIFF
--- a/jquery.flot.axislabels.js
+++ b/jquery.flot.axislabels.js
@@ -256,7 +256,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
         var offsets = this.calculateOffsets(box);
         this.elem = $('<div class="axisLabels ' + this.axisName +
                       'Label" style="position:absolute; ' +
-                      'color: ' + this.opts.color + '; ' +
+                      (this.opts.axisLabelColour ? 'color: ' + this.opts.axisLabelColour + '; ' : '') +
                       this.transforms(offsets.degrees, offsets.x, offsets.y) +
                       '">' + this.opts.axisLabel + '</div>');
         this.plot.getPlaceholder().append(this.elem);


### PR DESCRIPTION
HTML labels are currently hardcoded to use `this.opts.color`, which is used by flot for colouring gridlines. Since this is set as inline css, it's impossible to override with a stylesheet (using eg `.axisLabels {color: black;}`) and effectively means that the axis labels have to be the same colour as the gridlines.

This should probably use `this.opts.axisLabelColour` if it's been set, and otherwise omit the inline `color` declaration so that some global style can be applied.

Specifically the line

``` javascript
'color: ' + this.opts.color + '; ' + 
```

should be replaced with something like

``` javascript
(this.opts.axisLabelColour ? 'color: ' + this.opts.axisLabelColour + '; ' : '') +
```
