### PR TITLE
Added rounding to label positioning to avoid half pixel positions.

### DIFF
--- a/jquery.flot.axislabels.js
+++ b/jquery.flot.axislabels.js
@@ -252,6 +252,9 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                         - this.labelHeight/2;
             offsets.y = box.height/2 + box.top;
         }
+        offsets.x = Math.round(offsets.x);
+        offsets.y = Math.round(offsets.y);
+
         return offsets;
     };
 


### PR DESCRIPTION
This is a resolution to issue #30.  Sorry for not tieing them together, I really meant for it to but I guess I missed something in the process.
