### PR TITLE
Fix text alignment when using the canvas render.

### DIFF
--- a/jquery.flot.axislabels.js
+++ b/jquery.flot.axislabels.js
@@ -98,6 +98,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             this.opts.axisLabelColour = 'black';
         var ctx = this.plot.getCanvas().getContext('2d');
         ctx.save();
+        ctx.textAlign="left";
         ctx.font = this.opts.axisLabelFontSizePixels + 'px ' +
             this.opts.axisLabelFontFamily;
         ctx.fillStyle = this.opts.axisLabelColour;


### PR DESCRIPTION
I ran into a problem where labels drawn by the canvas renderer weren't properly centered.

Originally, they looked something like:

![label_misaligned](https://cloud.githubusercontent.com/assets/1379749/10542632/a0d80486-73e7-11e5-9405-378ec4391080.png)

With this change, they are properly centered:

![label_fixed](https://cloud.githubusercontent.com/assets/1379749/10542652/bc4955b2-73e7-11e5-8c01-5c58e0431494.png)
